### PR TITLE
[sprint-planner] Docs: expanded SKILL.md triggers, quick-start README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,64 @@ Or via Claude Code native marketplace:
 claude plugin install sprint-planner@musabkara-claude-marketplace
 ```
 
+## Quick Start
+
+```bash
+# 1. Run project analysis (generates analysis/MASTER_ANALYSIS.md)
+/project-analysis --all
+
+# 2. Preview the sprint plan without writing to Jira
+/sprint-plan --dry-run
+
+# 3. Generate plan and create Jira epics + tasks
+/sprint-plan
+
+# 4. Check if Jira is in sync with your local plan
+/sprint-plan sync
+```
+
 ## Features
 
-- **Plan Generation** -- Parse analysis reports or PRDs, extract tasks with priorities and story points, organize into time-boxed sprints
-- **Priority Mapping** -- Automatically categorize findings as P0-P3 based on severity (Critical/Must Have/Nice-to-Have)
-- **Sprint Organization** -- 5-sprint structure with themed focus areas (Security, Performance, UX, Growth, Monetization)
-- **Jira Integration** -- Create epics and stories with labels, story points, and acceptance criteria via Atlassian MCP
-- **Story Point Estimation** -- S=1, M=2, L=3, XL=5 scale with 25-35 SP capacity per sprint
+- **Plan Generation** — Parse analysis reports or PRDs, extract tasks with priorities and story points, organize into time-boxed sprints
+- **Priority Mapping** — Automatically categorize findings as P0-P3 based on severity (Critical/Must Have/Nice-to-Have)
+- **Adaptive Sprint Themes** — Sprint focus areas adapt to project type (mobile app, web, CLI, API, plugin)
+- **Jira Integration** — Create epics and stories with labels, story points, and acceptance criteria via Atlassian MCP
+- **Idempotent** — Re-running skips Jira epics/tasks that already exist; no duplicates
+- **Dry-run mode** — Preview SPRINT_PLAN.md without any Jira writes
+- **Dependency graph** — SPRINT_PLAN.md includes wave and depends_on columns for execution ordering
+- **Story Point Estimation** — S=1, M=2, L=3, XL=5 scale with configurable capacity per sprint
 
 ## Usage
 
 ```
 /sprint-plan                    # Full flow: generate plan + create Jira issues
 /sprint-plan plan-only          # Generate plan only (no Jira)
+/sprint-plan --dry-run          # Preview SPRINT_PLAN.md, no Jira writes
 /sprint-plan jira-only          # Push existing plan to Jira
+/sprint-plan sync               # Sync active Jira sprint with local plan
+/sprint-plan --sprints N        # Configure sprint count (default: 5)
+/sprint-plan --capacity N       # Configure SP capacity per sprint (default: 30)
 ```
 
 ## Prerequisites
 
 - `analysis/` directory with at least one analysis report (`.md`)
 - `analysis/MASTER_ANALYSIS.md` is used as the primary source when present
-- Atlassian MCP active for Jira integration (optional for plan-only mode)
+- Atlassian MCP active for Jira integration (optional for `plan-only` and `--dry-run`)
+- Jira project key in CLAUDE.md (auto-detected; fallback: asks user)
 
-## Sprint Structure
+## Sprint Structure (Adaptive)
 
-| Sprint | Focus                      | SP Capacity |
-|--------|----------------------------|-------------|
-| 1      | Security & Critical Fixes  | 25-35       |
-| 2      | Performance & Architecture | 25-35       |
-| 3      | UX & Accessibility         | 25-35       |
-| 4      | Analytics & Growth         | 25-35       |
-| 5      | Monetization & ASO         | 25-35       |
+Sprint themes are chosen based on project type detected from CLAUDE.md/README:
+
+| Project Type | Sprint Themes |
+|--------------|---------------|
+| Mobile app | UX → Performance → Security → Growth → ASO |
+| Web app | Security → Performance → UX → SEO → Growth |
+| CLI tool | Architecture → Testing → DX → Distribution → Docs |
+| API/backend | Security → Performance → Architecture → Testing → Docs |
+| Plugin | DX → Reliability → Docs → Examples → Distribution |
+| Unknown | Security → Performance → UX → Growth → Monetization |
 
 ## License
 

--- a/skills/sprint-planner/SKILL.md
+++ b/skills/sprint-planner/SKILL.md
@@ -3,15 +3,26 @@
 ## Trigger
 
 Auto-trigger when the user mentions any of the following:
-- sprint planning
-- backlog grooming / backlog refinement
-- epic creation
-- story points / estimation
-- sprint capacity
-- PRD to sprint / PRD to tasks
-- task breakdown / task extraction
-- sprint organization
-- velocity planning
+
+**Direct phrasings:**
+- sprint planning, sprint plan, plan my sprints, create sprint plan
+- backlog grooming, backlog refinement, groom backlog
+- epic creation, create epics, make jira issues
+- story points, estimation, point these tasks, estimate effort
+- sprint capacity, how many tasks per sprint
+- PRD to sprint, PRD to tasks, convert PRD to jira
+- task breakdown, task extraction, break down tasks, split into tasks
+- sprint organization, organize into sprints
+- velocity planning, plan velocity
+
+**Contextual phrasings (trigger when intent is clearly sprint planning):**
+- "turn this analysis into tasks"
+- "create jira issues from the analysis"
+- "how should I prioritize these"
+- "what should we do first" (when analysis files exist)
+- "plan the next sprint"
+- "push tasks to jira"
+- "sync my sprint"
 
 ## Description
 
@@ -23,8 +34,8 @@ Provides sprint planning capabilities: reads analysis reports or PRDs, extracts 
 - Parse `analysis/` directory for reports (MASTER_ANALYSIS.md preferred)
 - Extract findings with priority (P0-P3) and effort (S/M/L/XL)
 - Map effort to story points: S=1, M=2, L=3, XL=5
-- Organize tasks into 2-week sprints (25-35 SP each)
-- Generate `analysis/SPRINT_PLAN.md`
+- Organize tasks into 2-week sprints (configurable with --sprints)
+- Generate `analysis/SPRINT_PLAN.md` with wave/depends_on columns
 
 ### Priority Mapping
 | Source Category              | Priority |
@@ -33,7 +44,8 @@ Provides sprint planning capabilities: reads analysis reports or PRDs, extracts 
 | Improvement Suggestions      | P1/P2    |
 | Nice-to-Have                 | P2/P3    |
 
-### Sprint Structure
+### Adaptive Sprint Structure
+Sprint themes adapt to project type (mobile/web/CLI/API/plugin). Default:
 | Sprint | Focus                      |
 |--------|----------------------------|
 | 1      | Security & Critical Fixes  |
@@ -43,6 +55,8 @@ Provides sprint planning capabilities: reads analysis reports or PRDs, extracts 
 | 5      | Monetization & ASO         |
 
 ### Jira Integration
+- Auto-detect project key from CLAUDE.md
+- Idempotent: skips existing epics/tasks on re-run
 - Create epics per sprint: `[Sprint N] Focus Area`
 - Create stories/tasks under epics with:
   - English summary (max 80 chars)
@@ -60,11 +74,14 @@ Available labels for task categorization:
 ```
 /sprint-plan                    # Full flow: plan + Jira
 /sprint-plan plan-only          # Plan only
+/sprint-plan --dry-run          # Preview plan, no Jira writes
 /sprint-plan jira-only          # Push existing plan to Jira
 /sprint-plan sync               # Sync with Jira
+/sprint-plan --sprints N        # Configure sprint count
+/sprint-plan --capacity N       # Configure SP capacity per sprint
 ```
 
 ## Prerequisites
 
 - Analysis reports in `analysis/` directory
-- Atlassian MCP for Jira integration (optional for plan-only mode)
+- Atlassian MCP for Jira integration (optional for plan-only and --dry-run modes)


### PR DESCRIPTION
## Summary
- SKILL.md: adds contextual trigger phrases ("turn this analysis into tasks", "plan the next sprint", etc.)
- SKILL.md: updated commands list and capabilities to reflect new flags
- README: adds Quick Start section with 4-step flow
- README: updated Features list with new idempotency, dry-run, dependency graph features
- README: updated Usage with all new flags
- README: added adaptive sprint themes table by project type

Closes #6 (partially — docs portion)